### PR TITLE
Fix ImportError caused by missing django.conf.urls.defaults

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -161,7 +161,7 @@ admin.site.register(Company, CompanyAdmin)
 
 1. Add `"flexselect",` to `INSTALLED_APPS` in "settings.py".
 
-2. Add `(r'^flexselect/', include('flexselect.urls')),` to "urls.py".
+2. Add `url(r'^flexselect/', include('flexselect.urls')),` to "urls.py".
 
 ### Options ###
 As of yet, flexselect only have one configuration option, namely 

--- a/flexselect/urls.py
+++ b/flexselect/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns
 
 urlpatterns = patterns('flexselect.views',
     (r'field_changed', 'field_changed'),


### PR DESCRIPTION
This was removed in Django 1.6.
